### PR TITLE
Allow empty sections

### DIFF
--- a/nxo64.py
+++ b/nxo64.py
@@ -201,7 +201,6 @@ class SegmentBuilder(object):
         assert end is None or size is None
         if size is None:
             size = end-start
-        assert size > 0
         r = Range(start, size)
         for i in self.segments:
             if i.range.includes(r):


### PR DESCRIPTION
It looks like the assumption that sections will always have a non-zero size is invalid. BotW's 1.6.0 NSO has a 0-sized .fini_array.